### PR TITLE
`shiny-` and `shiny-theme-` prefixes, add bootstrap page adapter

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -49,7 +49,7 @@
     "build-js": "tsx scripts/build.ts",
     "watch-js": "npm run build-js -- --watch",
     "lint-styles": "npx stylelint \"**/*.ts\"",
-    "build-styles": "npx postcss src/styles/shiny-theme.css -o out/shiny-theme.css",
+    "build-styles": "npx postcss src/styles/shiny-theme.css -o out/shiny-theme.css && npx postcss src/styles/adapters/**/*.css --base src/styles/adapters -d out/adapters",
     "watch-styles": "npm run build-styles -- --watch",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/js/src/styles/adapters/component/shoelace-theme-adapter.css
+++ b/js/src/styles/adapters/component/shoelace-theme-adapter.css
@@ -7,91 +7,91 @@ automatically match the current open-props theme */
    */
 
   /* Primary */
-  --sl-color-primary-50: var(--brand);
-  --sl-color-primary-100: var(--brand);
-  --sl-color-primary-200: var(--brand);
-  --sl-color-primary-300: var(--brand);
-  --sl-color-primary-400: var(--brand);
-  --sl-color-primary-500: var(--brand);
-  --sl-color-primary-600: var(--brand);
-  --sl-color-primary-700: var(--brand);
-  --sl-color-primary-800: var(--brand);
-  --sl-color-primary-900: var(--brand);
-  --sl-color-primary-950: var(--brand);
+  --sl-color-primary-50: var(--shiny-brand);
+  --sl-color-primary-100: var(--shiny-brand);
+  --sl-color-primary-200: var(--shiny-brand);
+  --sl-color-primary-300: var(--shiny-brand);
+  --sl-color-primary-400: var(--shiny-brand);
+  --sl-color-primary-500: var(--shiny-brand);
+  --sl-color-primary-600: var(--shiny-brand);
+  --sl-color-primary-700: var(--shiny-brand);
+  --sl-color-primary-800: var(--shiny-brand);
+  --sl-color-primary-900: var(--shiny-brand);
+  --sl-color-primary-950: var(--shiny-brand);
 
   /* Success */
-  --sl-color-success-50: var(--success);
-  --sl-color-success-100: var(--success);
-  --sl-color-success-200: var(--success);
-  --sl-color-success-300: var(--success);
-  --sl-color-success-400: var(--success);
-  --sl-color-success-500: var(--success);
-  --sl-color-success-600: var(--success);
-  --sl-color-success-700: var(--success);
-  --sl-color-success-800: var(--success);
-  --sl-color-success-900: var(--success);
-  --sl-color-success-950: var(--success);
+  --sl-color-success-50: var(--shiny-success);
+  --sl-color-success-100: var(--shiny-success);
+  --sl-color-success-200: var(--shiny-success);
+  --sl-color-success-300: var(--shiny-success);
+  --sl-color-success-400: var(--shiny-success);
+  --sl-color-success-500: var(--shiny-success);
+  --sl-color-success-600: var(--shiny-success);
+  --sl-color-success-700: var(--shiny-success);
+  --sl-color-success-800: var(--shiny-success);
+  --sl-color-success-900: var(--shiny-success);
+  --sl-color-success-950: var(--shiny-success);
 
   /* Warning */
-  --sl-color-warning-50: var(--warning);
-  --sl-color-warning-100: var(--warning);
-  --sl-color-warning-200: var(--warning);
-  --sl-color-warning-300: var(--warning);
-  --sl-color-warning-400: var(--warning);
-  --sl-color-warning-500: var(--warning);
-  --sl-color-warning-600: var(--warning);
-  --sl-color-warning-700: var(--warning);
-  --sl-color-warning-800: var(--warning);
-  --sl-color-warning-900: var(--warning);
-  --sl-color-warning-950: var(--warning);
+  --sl-color-warning-50: var(--shiny-warning);
+  --sl-color-warning-100: var(--shiny-warning);
+  --sl-color-warning-200: var(--shiny-warning);
+  --sl-color-warning-300: var(--shiny-warning);
+  --sl-color-warning-400: var(--shiny-warning);
+  --sl-color-warning-500: var(--shiny-warning);
+  --sl-color-warning-600: var(--shiny-warning);
+  --sl-color-warning-700: var(--shiny-warning);
+  --sl-color-warning-800: var(--shiny-warning);
+  --sl-color-warning-900: var(--shiny-warning);
+  --sl-color-warning-950: var(--shiny-warning);
 
   /* Danger */
-  --sl-color-danger-50: var(--danger);
-  --sl-color-danger-100: var(--danger);
-  --sl-color-danger-200: var(--danger);
-  --sl-color-danger-300: var(--danger);
-  --sl-color-danger-400: var(--danger);
-  --sl-color-danger-500: var(--danger);
-  --sl-color-danger-600: var(--danger);
-  --sl-color-danger-700: var(--danger);
-  --sl-color-danger-800: var(--danger);
-  --sl-color-danger-900: var(--danger);
-  --sl-color-danger-950: var(--danger);
+  --sl-color-danger-50: var(--shiny-danger);
+  --sl-color-danger-100: var(--shiny-danger);
+  --sl-color-danger-200: var(--shiny-danger);
+  --sl-color-danger-300: var(--shiny-danger);
+  --sl-color-danger-400: var(--shiny-danger);
+  --sl-color-danger-500: var(--shiny-danger);
+  --sl-color-danger-600: var(--shiny-danger);
+  --sl-color-danger-700: var(--shiny-danger);
+  --sl-color-danger-800: var(--shiny-danger);
+  --sl-color-danger-900: var(--shiny-danger);
+  --sl-color-danger-950: var(--shiny-danger);
 
   /* Neutral one-offs */
   --sl-color-neutral-0: hsl(0deg 0% 100%);
   --sl-color-neutral-1000: hsl(0deg 0% 0%);
 
   /* Neutral */
-  --sl-color-neutral-50: var(--suface-3);
-  --sl-color-neutral-100: var(--surface-4);
-  --sl-color-neutral-200: var(--suface-4);
-  --sl-color-neutral-300: var(--text-3);
-  --sl-color-neutral-400: var(--text-3);
-  --sl-color-neutral-500: var(--text-3);
-  --sl-color-neutral-600: var(--text-2);
-  --sl-color-neutral-700: var(--text-2);
-  --sl-color-neutral-800: var(--text-1);
-  --sl-color-neutral-900: var(--text-1);
-  --sl-color-neutral-950: var(--text-1);
+  --sl-color-neutral-50: var(--shiny-surface-3);
+  --sl-color-neutral-100: var(--shiny-surface-4);
+  --sl-color-neutral-200: var(--shiny-surface-4);
+  --sl-color-neutral-300: var(--shiny-text-3);
+  --sl-color-neutral-400: var(--shiny-text-3);
+  --sl-color-neutral-500: var(--shiny-text-3);
+  --sl-color-neutral-600: var(--shiny-text-2);
+  --sl-color-neutral-700: var(--shiny-text-2);
+  --sl-color-neutral-800: var(--shiny-text-1);
+  --sl-color-neutral-900: var(--shiny-text-1);
+  --sl-color-neutral-950: var(--shiny-text-1);
 
   /*
    * Border radii
    */
-  --sl-border-radius-small: var(calc(--radius-s/2));
-  --sl-border-radius-medium: var(--radius-s);
-  --sl-border-radius-large: var(--radius-m);
-  --sl-border-radius-x-large: var(--radius-l);
+  --sl-border-radius-small: var(calc(--shiny-radius-s/2));
+  --sl-border-radius-medium: var(--shiny-radius-s);
+  --sl-border-radius-large: var(--shiny-radius-m);
+  --sl-border-radius-x-large: var(--shiny-radius-l);
   --sl-border-radius-circle: 50%;
-  --sl-border-radius-pill: var(--radius-pill);
+  --sl-border-radius-pill: var(--shiny-radius-pill);
 
   /*
    * Elevations
    */
   --sl-shadow-x-small: var(--shadow-1);
-  --sl-shadow-small: var(--shadow-2);
-  --sl-shadow-medium: var(--shadow-3);
-  --sl-shadow-large: var(--shadow-5);
+  --sl-shadow-small: var(--shiny-shadow-s, var(--shadow-2));
+  --sl-shadow-medium: var(--shiny-shadow-m, var(--shadow-3));
+  --sl-shadow-large: var(--shiny-shadow-l, var(--shadow-5));
   --sl-shadow-x-large: var(--shadow-6);
 
   /*
@@ -124,9 +124,9 @@ automatically match the current open-props theme */
    */
 
   /* Fonts */
-  --sl-font-mono: var(--font-mono);
-  --sl-font-sans: var(--font-sans);
-  --sl-font-serif: var(--font-serif);
+  --sl-font-mono: var(--shiny-font-mono);
+  --sl-font-sans: var(--shiny-font-sans);
+  --sl-font-serif: var(--shiny-font-serif);
 
   /* Font sizes */
   --sl-font-size-2x-small: var(--font-size-00); /* 10px */
@@ -180,7 +180,7 @@ automatically match the current open-props theme */
   --sl-input-height-small: var(--size-6); /* 30px */
   --sl-input-height-medium: var(--size-7); /* 40px */
   --sl-input-height-large: var(--size-8); /* 50px */
-  --sl-input-background-color: var(--surface-2);
+  --sl-input-background-color: var(--shiny-surface-2);
   --sl-input-background-color-hover: var(--sl-input-background-color);
   --sl-input-background-color-focus: var(--sl-input-background-color);
   --sl-input-background-color-disabled: var(--suface-4);
@@ -201,9 +201,9 @@ automatically match the current open-props theme */
   --sl-input-font-size-medium: var(--sl-font-size-medium);
   --sl-input-font-size-large: var(--sl-font-size-large);
   --sl-input-letter-spacing: var(--sl-letter-spacing-normal);
-  --sl-input-color: var(--text-2);
-  --sl-input-color-hover: var(--text-2);
-  --sl-input-color-focus: var(--text-2);
+  --sl-input-color: var(--shiny-text-2);
+  --sl-input-color-hover: var(--shiny-text-2);
+  --sl-input-color-focus: var(--shiny-text-2);
   --sl-input-color-disabled: var(--sl-color-neutral-900);
   --sl-input-icon-color: var(--sl-color-neutral-500);
   --sl-input-icon-color-hover: var(--sl-color-neutral-600);
@@ -213,9 +213,9 @@ automatically match the current open-props theme */
   --sl-input-spacing-small: var(--sl-spacing-small);
   --sl-input-spacing-medium: var(--sl-spacing-medium);
   --sl-input-spacing-large: var(--sl-spacing-large);
-  --sl-input-focus-ring-color: var(--brand);
+  --sl-input-focus-ring-color: var(--shiny-brand);
   --sl-input-focus-ring-offset: 0;
-  --sl-input-filled-background-color: var(--surface-1);
+  --sl-input-filled-background-color: var(--shiny-surface-1);
   --sl-input-filled-background-color-hover: var(
     --sl-input-filled-background-color
   );
@@ -251,13 +251,13 @@ automatically match the current open-props theme */
    * Overlays
    */
 
-  --sl-overlay-background-color: var(--brand);
+  --sl-overlay-background-color: var(--shiny-brand);
 
   /*
    * Panels
    */
 
-  --sl-panel-background-color: var(--surface-3);
+  --sl-panel-background-color: var(--shiny-surface-3);
   --sl-panel-border-color: var(--sl-color-neutral-200);
   --sl-panel-border-width: var(--border-size-1);
 
@@ -266,7 +266,7 @@ automatically match the current open-props theme */
    */
 
   --sl-tooltip-border-radius: var(--sl-border-radius-medium);
-  --sl-tooltip-background-color: var(--surface-3);
+  --sl-tooltip-background-color: var(--shiny-surface-3);
   --sl-tooltip-color: var(--sl-color-neutral-0);
   --sl-tooltip-font-family: var(--sl-font-sans);
   --sl-tooltip-font-weight: var(--sl-font-weight-normal);

--- a/js/src/styles/adapters/page/bootstrap-theme-adapter.css
+++ b/js/src/styles/adapters/page/bootstrap-theme-adapter.css
@@ -1,0 +1,36 @@
+:root {
+  --shiny-theme-gray-0: var(--bs-light);
+  --shiny-theme-gray-1: var(--bs-gray-100);
+  --shiny-theme-gray-2: var(--bs-gray-200);
+  --shiny-theme-gray-3: var(--bs-gray-300);
+  --shiny-theme-gray-4: var(--bs-gray-400);
+  --shiny-theme-gray-5: var(--bs-gray-500);
+  --shiny-theme-gray-6: var(--bs-gray-600);
+  --shiny-theme-gray-7: var(--bs-gray-700);
+  --shiny-theme-gray-8: var(--bs-gray-800);
+  --shiny-theme-gray-9: var(--bs-gray-900);
+  --shiny-theme-gray-10: var(--bs-gray-dark);
+  --shiny-theme-gray-11: var(--bs-dark);
+  --shiny-theme-gray-12: var(--bs-black);
+  --shiny-theme-surface-1: var(--bs-body-bg);
+  --shiny-theme-text-1: var(--bs-body-color);
+  --shiny-theme-surface-2: var(--bs-primary);
+  --shiny-theme-text-2: var(--bs-primary);
+  --shiny-theme-surface-3: var(--bs-secondary);
+  --shiny-theme-text-3: var(--bs-secondary);
+  --shiny-theme-surface-4: var(--bs-info);
+  --shiny-theme-text-4: var(--bs-info);
+  --shiny-theme-success: var(--bs-success);
+  --shiny-theme-warning: var(--bs-warning);
+  --shiny-theme-danger: var(--bs-danger);
+  --shiny-theme-brand: var(--bs-primary);
+  --shiny-theme-gradient-1: var(--bs-gradient);
+  --shiny-theme-text-1-dim: var(--bs-default);
+  --shiny-theme-font-sans: var(--bs-font-sans-serif);
+  --shiny-theme-font-mono: var(--bs-font-monospace);
+  /* not sure bs-font-serif exists */
+  --shiny-theme-font-serif: var(--bs-font-serif);
+  --shiny-theme-font-size-sm: calc(var(--bs-body-font-size) * 0.875);
+  --shiny-theme-font-size-m: var(--bs-body-font-size);
+  --shiny-theme-font-size-l: calc(var(--bs-body-font-size) * 1.5);
+}

--- a/js/src/styles/shiny-theme.css
+++ b/js/src/styles/shiny-theme.css
@@ -8,7 +8,7 @@ override styles from our reset layer */
 @import "color-themes/dark.css";
 @import "color-themes/dim.css";
 @import "color-themes/light.css";
-@import "shoelace-theme-adapter.css";
+@import "adapters/component/shoelace-theme-adapter.css";
 
 /* Import resets into a lower layer so they can be easily over-ridden */
 @import "resets.css" layer(reset);
@@ -19,103 +19,107 @@ override styles from our reset layer */
   /* Set defaults */
 
   /* The H of hsl for the brand color */
-  --brand-hue: var(--brand-light-hue);
-  --brand-hsl: var(--brand-light-hsl);
-  --brand: var(--brand-light);
-  --text-1: var(--text-1-light);
-  --text-2: var(--text-2-light);
-  --text-3: var(--text-3-light);
-  --surface-1: var(--surface-1-light);
-  --surface-2: var(--surface-2-light);
-  --surface-3: var(--surface-3-light);
-  --surface-4: var(--surface-4-light);
-  --shadow-color: var(--shadow-color-light);
-  --shadow-strength: var(--shadow-strength-light);
+  --shiny-brand-hue: var(--shiny-theme-brand-hue, var(--brand-light-hue));
+  --shiny-brand-hsl: var(--shiny-theme-brand-hsl, var(--brand-light-hsl));
+  --shiny-brand: var(--shiny-theme-brand, var(--brand-light));
+  --shiny-text-1: var(--shiny-theme-text-1, var(--text-1-light));
+  --shiny-text-2: var(--shiny-theme-text-2, var(--text-2-light));
+  --shiny-text-3: var(--shiny-theme-text-3, var(--text-3-light));
+  --shiny-surface-1: var(--shiny-theme-surface-1, var(--surface-1-light));
+  --shiny-surface-2: var(--shiny-theme-surface-2, var(--surface-2-light));
+  --shiny-surface-3: var(--shiny-theme-surface-3, var(--surface-3-light));
+  --shiny-surface-4: var(--shiny-theme-surface-4, var(--surface-4-light));
+  --shiny-shadow-color: var(--shiny-theme-shadow-color, var(--shadow-color-light));
+  --shiny-shadow-strength: var(--shiny-theme-shadow-strength, var(--shadow-strength-light));
 
   /* Status colors */
-  --success: var(--green-4);
-  --warning: var(--orange-8);
-  --danger: var(--red-8);
+  --shiny-primary: var(--shiny-theme-primary, var(--shiny-brand));
+  --shiny-success: var(--shiny-theme-success, var(--green-4));
+  --shiny-warning: var(--shiny-theme-warning, var(--orange-8));
+  --shiny-danger: var(--shiny-theme-danger, var(--red-8));
 
   /* Sizes */
 
   /* Things like adding padding around a toggle switch */
-  --size-xxs: var(--size-1);
-  --size-xs: var(--size-2);
-  --size-s: var(--size-3);
-  --size-m: var(--size-fluid-2);
-  --size-l: var(--size-fluid-3);
-  --size-xl: var(--size-fluid-5);
-  --size-xxl: var(--size-fluid-6);
+  --shiny-size-xxs: var(--shiny-theme-size-xxs, var(--size-1));
+  --shiny-size-xs: var(--shiny-theme-size-xs, var(--size-2));
+  --shiny-size-s: var(--shiny-theme-size-s, var(--size-3));
+  --shiny-size-m: var(--shiny-theme-size-m, var(--size-fluid-2));
+  --shiny-size-l: var(--shiny-theme-size-l, var(--size-fluid-3));
+  --shiny-size-xl: var(--shiny-theme-size-xl, var(--size-fluid-5));
+  --shiny-size-xxl: var(--shiny-theme-size-xxl, var(--size-fluid-6));
 
   /* Shadows */
-  --shadow-s: var(--shadow-1);
-  --shadow-m: var(--shadow-3);
-  --shadow-l: var(--shadow-5);
+  --shiny-shadow-s: var(--shiny-theme-shadow-s, var(--shadow-1));
+  --shiny-shadow-m: var(--shiny-theme-shadow-m, var(--shadow-3));
+  --shiny-shadow-l: var(--shiny-theme-shadow-l, var(--shadow-5));
 
   /* Text */
+  --shiny-font-mono: var(--shiny-theme-font-mono, var(--font-mono));
+  --shiny-font-sans: var(--shiny-theme-font-sans, var(--font-sans));
+  --shiny-font-serif: var(--shiny-theme-font-serif, var(--font-serif));
 
   /* Sizes */
-  --font-size-s: var(--font-size-0);
-  --font-size-m: var(--font-size-2);
-  --font-size-l: var(--font-size-4);
-  --font-size-h1: var(--font-size-fluid-2);
-  --font-size-h2: var(--font-size-fluid-1);
-  --font-size-h3: calc(var(--font-size-fluid-1) / 1.25));
-  --font-size-h4: calc(var(--font-size-fluid-1) / 1.5));
-  --font-size-h5: calc(var(--font-size-fluid-1) / 2));
+  --shiny-font-size-s: var(--shiny-theme-font-size-s, var(--font-size-0));
+  --shiny-font-size-m: var(--shiny-theme-font-size-m, var(--font-size-2));
+  --shiny-font-size-l: var(--shiny-theme-font-size-l, var(--font-size-4));
+  --shiny-font-size-h1: var(--shiny-theme-font-size-h1, var(--font-size-fluid-2));
+  --shiny-font-size-h2: var(--shiny-theme-font-size-h2, var(--font-size-fluid-1));
+  --shiny-font-size-h3: var(--shiny-theme-font-size-h3, calc(var(--font-size-fluid-1) / 1.25)));
+  --shiny-font-size-h4: var(--shiny-theme-font-size-h4, calc(var(--font-size-fluid-1) / 1.5)));
+  --shiny-font-size-h5: var(--shiny-theme-font-size-h5, calc(var(--font-size-fluid-1) / 2)));
 
   /* Special variable that allow text to size to its container smartly */
-  --font-size-fluid: clamp(
+  --shiny-font-size-fluid: var(--shiny-theme-font-size-fluid, clamp(
     var(--font-size-00),
     3cqi,
     var(--font-size-l)
-  );
+  ));
 
   /* Weights */
-  --font-weight-headings: var(--font-weight-3);
-  --font-weight-bold: var(--font-weight-5);
+  --shiny-font-weight-headings: var(--shiny-theme-font-weight-headings, var(--font-weight-4));
+  --shiny-font-weight-bold: var(--shiny-theme-font-weight-bold, var(--font-weight-5));
 
   /* Line heights */
-  --line-height-headings: var(--font-lineheight-1);
-  --line-height-main: var(--font-lineheight-3);
+  --shiny-line-height-headings: var(--shiny-theme-line-height-headings, var(--font-lineheight-1));
+  --shiny-line-height-main: var(--shiny-theme-line-height-main, var(--font-lineheight-3));
 
   /* Transitions */
-  --speed-fast: 0.15s;
-  --speed-normal: 0.3s;
-  --speed-slow: 0.75s;
+  --shiny-speed-fast: var(--shiny-theme-speed-fast, 0.15s);
+  --shiny-speed-normal: var(--shiny-theme-speed-normal, 0.3s);
+  --shiny-speed-slow: var(--shiny-theme-speed-slow, 0.75s);
 
   /* Borders */
-  --border-optional: 0;
-  --border-thin: var(--border-size-1);
-  --border-normal: var(--border-size-2);
-  --border-thick: var(--border-size-3);
+  --shiny-border-optional: var(--shiny-theme-border-optional, 0);
+  --shiny-border-thin: var(--shiny-theme-border-thin, var(--border-size-1));
+  --shiny-border-normal: var(--shiny-theme-border-normal, var(--border-size-2));
+  --shiny-border-thick: var(--shiny-theme-border-thick, var(--border-size-3));
 
   /* Border with a tinge of the brand color */
-  --border-color: hsl(var(--brand-hue) 10% 50% / 15%);
+  --shiny-border-color: var(--shiny-theme-border-standard, hsl(var(--brand-hue) 10% 50% / 15%));
   /* stylelint-disable-next-line declaration-block-no-duplicate-custom-properties */
-  --border-color: color-mix(in srgb, var(--brand) 20%, var(--surface-1));
-  --border-standard: var(--border-thin) solid var(--border-color);
+  --shiny-border-color: var(--shiny-theme-border-color, color-mix(in srgb, var(--brand) 20%, var(--surface-1)));
+  --shiny-border-standard: var(--shiny-theme-border-color, var(--border-thin) solid var(--border-color));
 
   /* Radii */
-  --radius-s: var(--radius-2);
-  --radius-m: var(--radius-3);
-  --radius-l: var(--radius-4);
-  --radius-pill: 9999px;
+  --shiny-radius-s: var(--shiny-theme-radius-s, var(--radius-2));
+  --shiny-radius-m: var(--shiny-theme-radius-m, var(--radius-3));
+  --shiny-radius-l: var(--shiny-theme-radius-l, var(--radius-4));
+  --shiny-radius-pill: var(--shiny-theme-radius-pill, 9999px);
 }
 
 @supports (font-size: 1cqi) {
   :is(.fluid-type) {
-    font-size: var(--font-size-fluid);
+    font-size: var(--shiny-font-size-fluid);
   }
 }
 
 /* Set transition speeds to zero when the user prefers reduced motion */
 @media (prefers-reduced-motion: reduce) {
   :root {
-    --speed-fast: 0s;
-    --speed-normal: 0s;
-    --speed-slow: 0s;
+    --shiny-speed-fast: 0s;
+    --shiny-speed-normal: 0s;
+    --shiny-speed-slow: 0s;
   }
 }
 
@@ -124,17 +128,17 @@ override styles from our reset layer */
   :root {
     color-scheme: dark;
 
-    --brand-hue: var(--brand-dark-hue);
-    --brand-hsl: var(--brand-dark-hsl);
-    --brand: var(--brand-dark);
-    --text-1: var(--text-1-dark);
-    --text-2: var(--text-2-dark);
-    --text-3: var(--text-3-dark);
-    --surface-1: var(--surface-1-dark);
-    --surface-2: var(--surface-2-dark);
-    --surface-3: var(--surface-3-dark);
-    --surface-4: var(--surface-4-dark);
-    --shadow-color: var(--shadow-color-dark);
-    --shadow-strength: var(--shadow-strength-dark);
+    --shiny-brand-hue: var(--shiny-theme-brand-hue, var(--brand-dark-hue));
+    --shiny-brand-hsl: var(--shiny-theme-brand-hsl, var(--brand-dark-hsl));
+    --shiny-brand: var(--shiny-theme-brand, var(--brand-dark));
+    --shiny-text-1: var(--shiny-theme-text-1, var(--text-1-dark));
+    --shiny-text-2: var(--shiny-theme-text-2, var(--text-2-dark));
+    --shiny-text-3: var(--shiny-theme-text-3, var(--text-3-dark));
+    --shiny-surface-1: var(--shiny-theme-surface-1, var(--surface-1-dark));
+    --shiny-surface-2: var(--shiny-theme-surface-2, var(--surface-2-dark));
+    --shiny-surface-3: var(--shiny-theme-surface-3, var(--surface-3-dark));
+    --shiny-surface-4: var(--shiny-theme-surface-4, var(--surface-4-dark));
+    --shiny-shadow-color: var(--shiny-theme-shadow-color, var(--shadow-color-dark));
+    --shiny-shadow-strength: var(--shiny-theme-shadow-strength, var(--shadow-strength-dark));
   }
 }


### PR DESCRIPTION
WIP, mostly for discussion and tinkering. This PR does a few things:

1. First, I added the `shiny-` prefix to props that are officially part of our design system, e.g. `--shiny-text-1` instead of `--text-1`.

2. I added a new layer of variables that are intended to be "public" facing in the sense that they can be modified at the page level or by page-level CSS. These are prefixed with `shiny-theme-`, e.g. `--shiny-theme-text-1`. The explicit goal of these properties is to serve page-level adapters in situations where we want the shiny design system to inherit from the page.

3. The `--shiny-*` tokens in this system are considered the component-facing properties; these should be used by the web components or by adapters for web components. I updated the shoelace adapter to use these tokens.


The motivation for this is two-fold:

1. First, it increases clarity around the source of our design tokens. Without the `shiny-` prefix, it can be hard to tell which properties come from open props and which properties are aliases we've created ourselves.

2. CSS variables cannot refer to themselves, so for page-level adapters to set a CSS variable, the fallback value in that adapter cannot refer to the variable being set. Introducing `--shiny-theme-*` allows page-level adapters to be included in more situations and reduces the risk that an unset variable will break a design token variable.